### PR TITLE
Make sure base path is a string before calling setServerParameter

### DIFF
--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -55,7 +55,7 @@ class BrowserKitDriver extends CoreDriver
         $this->client->followRedirects(true);
 
         if ($baseUrl !== null && $client instanceof HttpKernelBrowser) {
-            $client->setServerParameter('SCRIPT_FILENAME', parse_url($baseUrl, PHP_URL_PATH));
+            $client->setServerParameter('SCRIPT_FILENAME', parse_url($baseUrl, PHP_URL_PATH) ?? '');
         }
     }
 


### PR DESCRIPTION
If you have a config like this:

```
default:
    extensions:
        Behat\MinkExtension:
            base_url: "http://admin:admin@127.0.0.1:4242"
```

path is `null` when parsing the base URL with `parse_url`, which fails because of the typehint in `AbstractBrowser::setServerParameter`.

Using `http://admin:admin@127.0.0.1:4242/` (with `/` at the end) also helps, but it might be okay to allow the URL without `/` as it is also perfecly valid.