### PR TITLE
Allow PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
 
     "require": {
-        "php":                  "^7.2",
+        "php":                  ">=7.2",
         "behat/mink":           "^1.7",
         "symfony/browser-kit":  "^4.4|^5.0",
         "symfony/dom-crawler":  "^4.4|^5.0"


### PR DESCRIPTION
I didn't check compatibility with PHP 8 itself.
This change only ensures that any version above PHP 7.2 is allowed.