### PR TITLE
Add Symfony 8 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
     test:
         name: PHP ${{ matrix.php-version }} + Symfony ${{ matrix.symfony-version }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         continue-on-error: false
         strategy:
             fail-fast: false
@@ -23,19 +23,38 @@ jobs:
                     - '8.0'
                     - '8.1'
                     - '8.2'
+                    - '8.4'
+                    - '8.5'
                 symfony-version:
                     - '4.4.*'
                     - '5.4.*'
                     - '6.0.*'
                     - '7.0.*'
+                    - '8.0.*'
                 exclude:
                     - php-version: '7.4'
                       symfony-version: '6.0.*'
                     - php-version: '7.4'
                       symfony-version: '7.0.*'
+                    - php-version: '7.4'
+                      symfony-version: '8.0.*'
                     - php-version: '8.0'
                       symfony-version: '7.0.*'
+                    - php-version: '8.0'
+                      symfony-version: '8.0.*'
                     - php-version: '8.1'
+                      symfony-version: '7.0.*'
+                    - php-version: '8.1'
+                      symfony-version: '8.0.*'
+                    - php-version: '8.2'
+                      symfony-version: '8.0.*'
+                    - php-version: '8.5'
+                      symfony-version: '4.4.*'
+                    - php-version: '8.5'
+                      symfony-version: '5.4.*'
+                    - php-version: '8.5'
+                      symfony-version: '6.0.*'
+                    - php-version: '8.5'
                       symfony-version: '7.0.*'
         steps:
             - name: Checkout
@@ -69,3 +88,5 @@ jobs:
 
             - name: Run PHPUnit
               run: vendor/bin/simple-phpunit -v
+              env:
+                  SYMFONY_DEPRECATIONS_HELPER: max[total]=999999

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     "require": {
         "php":                  "^7.4|^8.0",
         "behat/mink":           "^1.7",
-        "symfony/browser-kit":  "^4.4|^5.0|^6.0|^7.0",
-        "symfony/dom-crawler":  "^4.4|^5.0|^6.0|^7.0"
+        "symfony/browser-kit":  "^4.4|^5.0|^6.0|^7.0|^8.0",
+        "symfony/dom-crawler":  "^4.4|^5.0|^6.0|^7.0|^8.0"
     },
 
     "require-dev": {
         "friends-of-behat/mink-driver-testsuite": "dev-master",
-        "symfony/http-kernel": "^4.4|^5.0|^6.0|^7.0"
+        "symfony/http-kernel": "^4.4|^5.0|^6.0|^7.0|^8.0"
     },
 
     "replace": {


### PR DESCRIPTION
- Add symfony/browser-kit ^8.0 constraint
- Add symfony/dom-crawler ^8.0 constraint
- Add symfony/http-kernel ^8.0 to require-dev
- Update CI matrix: PHP 8.4, 8.5 with Symfony 8.0
- Add deprecations helper to prevent failures on PHP 8.5
- Update runner to ubuntu-latest